### PR TITLE
remove outdated Grid from dependencies

### DIFF
--- a/PlexusStatusRD_Cata.toc
+++ b/PlexusStatusRD_Cata.toc
@@ -9,8 +9,7 @@
 ## Notes: Debuff List for Cataclysm
 ## Author: Stassart (Trelis-Proudmoore-US),Doadin
 ## Grid Author: Pastamancer & Maia
-## Dependencies: PlexusStatusRaidDebuff
-## OptionalDeps: Grid, Plexus
+## Dependencies: PlexusStatusRaidDebuff, Plexus
 ## X-Curse-Project-ID: 28185
 
 BaradinHold.lua


### PR DESCRIPTION
Grid is broken with Shadowlands.
If the fork is renamed and the prefix changed to plexus, we can safely depend on it